### PR TITLE
Support plan only

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ steps:
 ```
 
 As with `release`, this will synthesise an application version. You can specify a `newState` input to pass
-the `--new-state` option.
+the `--new-state` option and/or a `planOnly` input to pass the `--plan-only` option.

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'create a new state file when deploying'
     required: true
     default: 'false'
+  planOnly:
+    description: 'show the terraform plan only, without applying it'
+    required: true
+    default: 'false'
   appVersion:
     description: 'version of app for deploy/release commands'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -9669,6 +9669,9 @@ if (cdflowCommand !== "") {
     if (cdflowCommand === "deploy" && (0,_actions_core__WEBPACK_IMPORTED_MODULE_2__.getBooleanInput)("newState")) {
         args.push("--new-state");
     }
+    if ((cdflowCommand === "deploy" || cdflowCommand === "destroy") && (0,_actions_core__WEBPACK_IMPORTED_MODULE_2__.getBooleanInput)("planOnly")) {
+        args.push("--plan-only");
+    }
     if (cdflowCommand === "deploy" || cdflowCommand === "destroy" || cdflowCommand === "shell") {
         args.push((0,_actions_core__WEBPACK_IMPORTED_MODULE_2__.getInput)("environment"));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,10 @@ if (cdflowCommand !== "") {
         args.push("--new-state")
     }
 
+    if ((cdflowCommand === "deploy" || cdflowCommand === "destroy") && getBooleanInput("planOnly")) {
+        args.push("--plan-only")
+    }
+
     if (cdflowCommand === "deploy" || cdflowCommand === "destroy" || cdflowCommand === "shell") {
         args.push(getInput("environment"))
     }


### PR DESCRIPTION
This adds a new optional boolean input `planOnly` which when set to true passes the "--plan-only" option to cdflow2 if the cdflow2 command is deploy or destroy.

This allows for workflows where you want to see what terraform would change before it actually does it.